### PR TITLE
fix(blog): point manifest URL at the renamed /blogs/ Pages path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,4 @@ EMAIL_PASS=your_app_password_here
 
 # Blog manifest (posts.json) published by the separate Docusaurus blog repo.
 # Defaults to the GitHub Pages URL if unset. Override per-environment in Netlify.
-BLOG_MANIFEST_URL=https://kushalkrishnappa.github.io/blog/posts.json
+BLOG_MANIFEST_URL=https://kushalkrishnappa.github.io/blogs/posts.json

--- a/docs/superpowers/specs/2026-06-24-blog-sync-design.md
+++ b/docs/superpowers/specs/2026-06-24-blog-sync-design.md
@@ -63,7 +63,7 @@ Two coordinated work-streams (blog repo setup; portfolio changes) bound by the
 
 ## 5. Data Contract — `posts.json`
 
-Served at the blog site root (e.g. `https://kushalkrishnappa.github.io/blog/posts.json`).
+Served at the blog site root (e.g. `https://kushalkrishnappa.github.io/blogs/posts.json`).
 
 ```json
 {
@@ -75,7 +75,7 @@ Served at the blog site root (e.g. `https://kushalkrishnappa.github.io/blog/post
       "date": "2026-07-01",
       "summary": "One-line teaser.",
       "tags": ["distributed-systems", "temporal"],
-      "url": "https://kushalkrishnappa.github.io/blog/first-post",
+      "url": "https://kushalkrishnappa.github.io/blogs/first-post",
       "readingTime": "5 min read"
     }
   ]
@@ -94,7 +94,7 @@ Rules:
 - Standard Docusaurus site. Posts authored as `.md` / `.mdx` with frontmatter:
   `title`, `date`, `description` (→ `summary`), `tags`, `slug`, `draft`.
 - Recommendation: set the blog plugin `routeBasePath: '/'` so post URLs are clean
-  (`…/blog/<slug>`, not `…/blog/blog/<slug>`). Moving to a custom subdomain later only
+  (`…/blogs/<slug>`, not `…/blogs/blog/<slug>`). Moving to a custom subdomain later only
   changes the base URL used to build `url`.
 - **`scripts/generate-manifest.mjs`** (Node, uses `gray-matter` — already in the
   Docusaurus dependency tree, so zero new deps): reads each post's frontmatter, computes

--- a/src/lib/blog.test.ts
+++ b/src/lib/blog.test.ts
@@ -116,7 +116,7 @@ describe("getAllPosts", () => {
     vi.stubGlobal("fetch", fetchMock);
     await getAllPosts();
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://kushalkrishnappa.github.io/blog/posts.json",
+      "https://kushalkrishnappa.github.io/blogs/posts.json",
       { cache: "force-cache" },
     );
   });

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,6 +1,6 @@
 import { BlogPostMeta } from "@/types";
 
-const DEFAULT_MANIFEST_URL = "https://kushalkrishnappa.github.io/blog/posts.json";
+const DEFAULT_MANIFEST_URL = "https://kushalkrishnappa.github.io/blogs/posts.json";
 
 function manifestUrl(): string {
   return process.env.BLOG_MANIFEST_URL || DEFAULT_MANIFEST_URL;


### PR DESCRIPTION
## Why

The blog repo was renamed `kushalkrishnappa/blog` → `kushalkrishnappa/blogs`, which moves its GitHub Pages project path from `/blog/` to `/blogs/`. GitHub redirects repository URLs after a rename, but project Pages paths derive from the repo name, so the old manifest URL now 404s:

```
https://kushalkrishnappa.github.io/blog/posts.json   -> 404
https://kushalkrishnappa.github.io/blogs/posts.json  -> 200
```

Without this change `getAllPosts()` fails its fetch, hits the fail-soft path and returns `[]`, so the blog cards render the "Working on it…" placeholder.

## Changes

- `src/lib/blog.ts` — `DEFAULT_MANIFEST_URL` now points at `/blogs/posts.json`
- `.env.example` — same for the documented default
- `src/lib/blog.test.ts` — the fallback-URL assertion
- `docs/superpowers/specs/2026-06-24-blog-sync-design.md` — documents the live `posts.json` contract, so the example URLs were updated too

`docs/superpowers/plans/2026-06-24-portfolio-blog-sync.md` was left alone as a dated record of the original implementation.

## Action needed outside this PR

If `BLOG_MANIFEST_URL` is set as a **Netlify env override** it still points at `/blog/` and takes precedence over this default — it needs updating in the Netlify UI. Nothing in the repo can see or change that value.

The blog repo's own `baseUrl` fix is on its `feat/kush` branch and not yet merged, so `/blogs/posts.json` currently serves a build whose post `url` fields still say `/blog/`. Merge that first, or the cards will link to 404s.

## Testing

`npx vitest run` — 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)